### PR TITLE
remove empty parameters from the request

### DIFF
--- a/lib/active_merchant/billing/gateways/be2bill.rb
+++ b/lib/active_merchant/billing/gateways/be2bill.rb
@@ -104,6 +104,8 @@ module ActiveMerchant #:nodoc:
         parameters[:IDENTIFIER] = @options[:login]
         parameters[:VERSION]    = '2.0'
 
+        parameters.delete_if { |k,v| v.blank? }
+
         url = (test? ? self.test_url : self.live_url)
         response = parse(ssl_post(url, post_data(action, parameters)))
 


### PR DESCRIPTION
be2bill doesn't like blank parameters, would rather they just aren't
there.